### PR TITLE
Require npm v1.4.4 or greater

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "hubot-slack": "^3.4.2"
   },
   "engines": {
-    "node": "0.10.x"
+    "node": "0.10.x",
+    "npm": ">= 1.4.4"
   },
   "scripts": {
     "start": "bash ./bin/hubot"


### PR DESCRIPTION
The application is failing to start on Azure due to "CERT_UNTRUSTED" errors while restoring packages. A blog post on Feb. 27th, 2014, suggests upgrading npm as a workaround for this error. The latest version as of the time of that blog post was v1.4.4, so we should require that version in package.json.