### PR TITLE
Remove hubot-github-webhook-listener to fix error loading it on Azure

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -7,6 +7,5 @@
   "hubot-google-translate",
   "hubot-maps",
   "hubot-rules",
-  "hubot-shipit",
-  "hubot-github-webhook-listener"
+  "hubot-shipit"
 ]


### PR DESCRIPTION
From the logs:

```
[Fri Jan 22 2016 16:07:57 GMT+0000 (Coordinated Universal Time)] ERROR Error loading scripts from npm package - Error: Cannot find module 'hubot-github-webhook-listener'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.Module._load (module.js:289:25)
  at Module.require (module.js:366:17)
  at require (module.js:385:17)
  at Robot.loadExternalScripts (D:\home\site\wwwroot\node_modules\hubot\src\robot.coffee:399:11)
  at D:\home\site\wwwroot\node_modules\hubot\bin\hubot.coffee:121:17
  at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:380:3)
```